### PR TITLE
Use more compatible output redirection

### DIFF
--- a/shini.sh
+++ b/shini.sh
@@ -6,7 +6,7 @@
 
 shini_function_exists()
 {
-	type "$1" &> /dev/null
+	type "$1" > /dev/null 2>&1
 	return $?
 }
 


### PR DESCRIPTION
The `&>` construct seems to be only supported in Bash 4, according to the documentation: http://www.tldp.org/LDP/abs/html/io-redirection.html.
KSH doesn't support it either -- at least version `93u+` on my Ubuntu 14.04.
The redirection to `stdout` is then not effective, making `shini` echo `__shini_parsed_section is a function` when parsing.