### PR TITLE
Add newline character in error message

### DIFF
--- a/shini.sh
+++ b/shini.sh
@@ -62,7 +62,7 @@ shini_parse()
 		if shini_function_exists "__shini_file_unreadable${POSTFIX}"; then
 			"__shini_file_unreadable${POSTFIX}" "$INI_FILE" "$EXTRA1" "$EXTRA2" "$EXTRA3"
 		else
-			printf 'shini: Unable to read INI file:\n  `%s`' "$INI_FILE" 1>&2
+			printf 'shini: Unable to read INI file:\n  `%s`\n' "$INI_FILE" 1>&2
 			exit 253
 		fi
 	fi


### PR DESCRIPTION
To be in line with other error messages, this one should have a newline character at its end as well.